### PR TITLE
Fix :: 급식 정보 apiKey 추가

### DIFF
--- a/lib/src/main/java/com/leeseojune/neisapi/NeisApi.java
+++ b/lib/src/main/java/com/leeseojune/neisapi/NeisApi.java
@@ -89,17 +89,19 @@ public class NeisApi {
      * @param day                                                       ex)20210616
      * @param scCode Neis calls this parameter "ATPT_OFCDC_SC_CODE"     ex)G10
      * @param schoolCode Neis calls this parameter "SD_SCHUL_CODE"      ex)7430310
+     * @param apiKey Neis calls this parameter "KEY"                    ex)794ba8d38c6820490216b865063c7b28
      * @return Meals breakfast, lunch, dinner
      * @throws ParseException if an error occurs during parsing
      */
-    public Meal getMealsByAbsoluteDay(String day, String scCode, String schoolCode) throws ParseException {
+    public Meal getMealsByAbsoluteDay(String day, String scCode, String schoolCode, String apiKey) throws ParseException {
         Document doc;
 
         try{
             DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
             DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
             doc = dBuilder.parse(mealHost + "?ATPT_OFCDC_SC_CODE=" + scCode + "&SD_SCHUL_CODE=" + schoolCode
-                    + "&MLSV_YMD=" + day);
+                    + "&MLSV_YMD=" + day
+                    + "&KEY=" + apiKey);
         }catch(ParserConfigurationException | SAXException | IOException e){
             throw new ParseException();
         }
@@ -111,10 +113,11 @@ public class NeisApi {
      * @param day                                                       ex)10
      * @param scCode Neis calls this parameter "ATPT_OFCDC_SC_CODE"     ex)G10
      * @param schoolCode Neis calls this parameter "SD_SCHUL_CODE"      ex)7430310
+     * @param apiKey Neis calls this parameter "KEY"                    ex)794ba8d38c6820490216b865063c7b28
      * @return Meals breakfast, lunch, dinner
      * @throws ParseException if an error occurs during parsing
      */
-    public Meal getMealsByRelativeDay(int day, String scCode, String schoolCode) throws ParseException {
+    public Meal getMealsByRelativeDay(int day, String scCode, String schoolCode, String apiKey) throws ParseException {
         LocalDate date = LocalDate.now().plusDays(day);
         Document doc;
 
@@ -122,7 +125,8 @@ public class NeisApi {
             DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
             DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
             doc = dBuilder.parse(mealHost + "?ATPT_OFCDC_SC_CODE=" + scCode + "&SD_SCHUL_CODE=" + schoolCode
-                    + "&MLSV_YMD=" + date.toString().replace("-", ""));
+                    + "&MLSV_YMD=" + date.toString().replace("-", "")
+                    + "&KEY=" + apiKey);
         }catch(ParserConfigurationException | SAXException | IOException e){
             throw new ParseException();
         }


### PR DESCRIPTION
나이스가 최근 4세대 지능형 나이스 업데이트 이후로 급식 정보를 불러올 때 API 키를 요구하기에 (기본 키 사용시 5건만 반환함) getMealsByAbsoluteDay와 getMealsByRelativeDay에 apiKey 파라미터를 추가하였습니다.